### PR TITLE
Use debugging features

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -1,6 +1,9 @@
 name: Debug
 
-on: [push]
+on: 
+  push:
+    branches:
+      - debug
 
 jobs:
   debug:

--- a/dist/index.js
+++ b/dist/index.js
@@ -5567,17 +5567,19 @@ try {
   // get tag-pattern-matcher
   const pattern = core.getInput('pattern')
   const tag = core.getInput('tag_name')
-  console.log(`Parsing ${tag} with ${pattern} tag for this run`)
-  console.log('tag', tag)
+
+  core.info(`Parsing ${tag} with ${pattern} tag for this run`)
 
   // this will be a function to parse the input against the event payload
   // to produce a refined tag
+  const strategy_tag = 'latest'
 
   // finally, return output
-  core.setOutput("strategy_tag", 'latest')
+  core.setOutput("strategy_tag", strategy_tag)
+
 } catch (error) {
   // do error handling stuff
-  console.error(error)
+  core.error(error)
   core.setFailed('CHIEF screwed up somewhere')
 }
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const core = require('@actions/core')
 const github = require('@actions/github')
 
 try {
-  console.log(github.context)
+  core.debug(JSON.stringify(github.context))
 
   // get tag-pattern-matcher
   const pattern = core.getInput('pattern')

--- a/index.js
+++ b/index.js
@@ -7,16 +7,18 @@ try {
   // get tag-pattern-matcher
   const pattern = core.getInput('pattern')
   const tag = core.getInput('tag_name')
-  console.log(`Parsing ${tag} with ${pattern} tag for this run`)
-  console.log('tag', tag)
+
+  core.info(`Parsing ${tag} with ${pattern} tag for this run`)
 
   // this will be a function to parse the input against the event payload
   // to produce a refined tag
+  const strategy_tag = 'latest'
 
   // finally, return output
-  core.setOutput("strategy_tag", 'latest')
+  core.setOutput("strategy_tag", strategy_tag)
+
 } catch (error) {
   // do error handling stuff
-  console.error(error)
+  core.error(error)
   core.setFailed('CHIEF screwed up somewhere')
 }


### PR DESCRIPTION
- uses `core.debug`, `core.info`, and `core.error` instead of `console.log`
- setup debugging workflow to only run on pushes to the debug branch